### PR TITLE
Enhance Tower and Realty Doctypes: Add New Fields, Filters, and Update Naming Series

### DIFF
--- a/bounya/albounya/doctype/office/office.json
+++ b/bounya/albounya/doctype/office/office.json
@@ -24,12 +24,13 @@
   {
    "fieldname": "custom_office_no",
    "fieldtype": "Data",
-   "label": "Office No"
+   "label": "Office No",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-10-08 10:49:08.736562",
+ "modified": "2024-11-12 12:49:49.127935",
  "modified_by": "Administrator",
  "module": "Albounya",
  "name": "Office",

--- a/bounya/albounya/doctype/realty/realty.js
+++ b/bounya/albounya/doctype/realty/realty.js
@@ -3,20 +3,20 @@
 
 frappe.ui.form.on('Realty', {
 	validate: function(frm) {
-		let naming = frm.doc.branch 
+		// let naming = frm.doc.branch 
 
-		if (frm.doc.office_no){
-			naming = naming + "/" +frm.doc.office_no
-		}
-		if (frm.doc.location_no){
-			naming = naming + "/" +frm.doc.location_no
-		}	
+		// if (frm.doc.office_no){
+		// 	naming = naming + "/" +frm.doc.office_no
+		// }
+		// if (frm.doc.location_no){
+		// 	naming = naming + "/" +frm.doc.location_no
+		// }	
 		
-		if (frm.doc.realty_no ){
-			naming = naming + "/" +frm.doc.realty_no 
-		}
-		frm.doc.realty_name = naming;
-		frm.refresh_field("realty_name");
+		// if (frm.doc.realty_no ){
+		// 	naming = naming + "/" +frm.doc.realty_no 
+		// }
+		// frm.doc.realty_name = naming;
+		// frm.refresh_field("realty_name");
 
 		if (frm.doc.realty_type == "Land Plot with building"){
 			if (frm.doc.realty_ct){

--- a/bounya/albounya/doctype/realty/realty.json
+++ b/bounya/albounya/doctype/realty/realty.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "field:realty_name",
+ "autoname": "format:{branch}-{office_no}-{location_no}-{realty_no}",
  "creation": "2024-06-19 10:29:36.204267",
  "default_view": "List",
  "doctype": "DocType",
@@ -457,14 +457,16 @@
    "fetch_from": "office.custom_office_no",
    "fieldname": "office_no",
    "fieldtype": "Data",
-   "hidden": 1,
-   "label": "Office No"
+   "label": "Office No",
+   "read_only": 1,
+   "reqd": 1
   },
   {
    "fieldname": "location",
    "fieldtype": "Link",
    "label": "Location",
-   "options": "Realty Location"
+   "options": "Realty Location",
+   "reqd": 1
   },
   {
    "fieldname": "realty_name",
@@ -477,18 +479,19 @@
    "fetch_from": "location.location_no",
    "fieldname": "location_no",
    "fieldtype": "Data",
-   "hidden": 1,
-   "label": "Location No"
+   "label": "Location No",
+   "read_only": 1,
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-10-08 16:06:26.649888",
+ "modified": "2024-11-12 12:58:11.593541",
  "modified_by": "Administrator",
  "module": "Albounya",
  "name": "Realty",
- "naming_rule": "By fieldname",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/bounya/albounya/doctype/realty/realty.json
+++ b/bounya/albounya/doctype/realty/realty.json
@@ -472,8 +472,7 @@
    "fieldname": "realty_name",
    "fieldtype": "Data",
    "label": "Realty Name",
-   "read_only": 1,
-   "unique": 1
+   "reqd": 1
   },
   {
    "fetch_from": "location.location_no",
@@ -487,7 +486,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-11-12 12:58:11.593541",
+ "modified": "2024-11-12 13:02:00.255450",
  "modified_by": "Administrator",
  "module": "Albounya",
  "name": "Realty",
@@ -563,5 +562,6 @@
  "search_fields": "realty_type,branch",
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "title_field": "realty_name"
 }

--- a/bounya/albounya/doctype/tower_type/tower_type.json
+++ b/bounya/albounya/doctype/tower_type/tower_type.json
@@ -9,6 +9,7 @@
  "engine": "InnoDB",
  "field_order": [
   "type",
+  "tower_type",
   "pricing_matrix"
  ],
  "fields": [
@@ -26,11 +27,20 @@
    "label": "Pricing Matrix",
    "options": "Pricing Matrix",
    "reqd": 1
+  },
+  {
+   "fieldname": "tower_type",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Tower Type",
+   "options": "\n\u0623\u0628\u0631\u0627\u062c \u0642\u0627\u0626\u0645\u0629 \u0630\u0627\u062a\u064a\u0629\n\u0623\u0628\u0631\u0627\u062c \u0642\u0627\u0626\u0645\u0629 \u0628\u0627\u0644\u0623\u0633\u0644\u0627\u0643",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-09-25 11:47:43.015667",
+ "modified": "2024-11-12 12:34:22.631390",
  "modified_by": "Administrator",
  "module": "Albounya",
  "name": "Tower Type",

--- a/bounya/albounya/doctype/towers/towers.js
+++ b/bounya/albounya/doctype/towers/towers.js
@@ -13,6 +13,16 @@ frappe.ui.form.on('Towers', {
 			};
 		});
 	},
+	tower_type_select: function(frm) {
+		frm.set_value("tower_type",)
+		frm.set_query("tower_type", function() {
+            return {
+                filters: [
+                    ["Tower Type","tower_type", "=", frm.doc.tower_type_select]
+                ]
+            }
+        });
+	},
 	branch: function(frm) {
 		frm.set_query("office", function() {
 			return {

--- a/bounya/albounya/doctype/towers/towers.json
+++ b/bounya/albounya/doctype/towers/towers.json
@@ -1,7 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
- "autoname": "naming_series:naming_series",
+ "autoname": "format:Tower-{tower_name}",
  "creation": "2024-09-02 09:14:23.665496",
  "default_view": "List",
  "doctype": "DocType",
@@ -10,6 +10,7 @@
  "field_order": [
   "naming_series",
   "tower_name",
+  "tower_type_select",
   "tower_type",
   "region",
   "allow_equipment_installation",
@@ -51,7 +52,7 @@
    "in_standard_filter": 1,
    "label": "Tower Name",
    "reqd": 1,
-   "search_index": 1
+   "unique": 1
   },
   {
    "fieldname": "column_break_5xew4",
@@ -145,9 +146,11 @@
    "read_only": 1
   },
   {
+   "depends_on": "tower_type_select",
    "fieldname": "tower_type",
    "fieldtype": "Link",
    "label": "Tower Type",
+   "mandatory_depends_on": "tower_type_select",
    "options": "Tower Type"
   },
   {
@@ -231,16 +234,24 @@
    "fieldname": "latitude",
    "fieldtype": "Data",
    "label": "Latitude"
+  },
+  {
+   "fieldname": "tower_type_select",
+   "fieldtype": "Select",
+   "in_list_view": 1,
+   "in_standard_filter": 1,
+   "label": "Tower Type",
+   "options": "\n\u0623\u0628\u0631\u0627\u062c \u0642\u0627\u0626\u0645\u0629 \u0630\u0627\u062a\u064a\u0629\n\u0623\u0628\u0631\u0627\u062c \u0642\u0627\u0626\u0645\u0629 \u0628\u0627\u0644\u0623\u0633\u0644\u0627\u0643"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-10-06 13:52:31.420304",
+ "modified": "2024-11-12 12:42:23.746782",
  "modified_by": "Administrator",
  "module": "Albounya",
  "name": "Towers",
- "naming_rule": "By \"Naming Series\" field",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -273,5 +284,6 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
+ "title_field": "tower_name",
  "track_changes": 1
 }


### PR DESCRIPTION
This update introduces several improvements to the **Towers** and **Realty** doctypes for better data handling and filtering based on specific requirements. The key changes are:

**1. New Tower Type Field:**
- Added a new `Tower Type` select field in the **Towers** doctype with values: "أبراج قائمة ذاتية" and "أبراج قائمة بالأسلاك".
- Added the same `Tower Type` field to the **Tower Type** doctype and implemented a filter in the **Towers** doctype, allowing users to filter `Tower Type` based on the selected option.

**2. Naming Series Updates:**
- **Towers Doctype:** Updated the naming series to follow the format `Tower-{Tower Name}` as required.
- **Realty Doctype:** Updated the naming series to follow the format `{Branch Name}-{Office Number}-{Location Number}-{Realty Number}`, ensuring consistent and descriptive naming.

**3. Mandatory Field in Office Doctype:**
- Set the `Office Number` field as mandatory in the **Office** doctype to enforce data integrity and ensure all records have an office number.